### PR TITLE
Optimize binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,9 @@ wasm-bindgen = "0.2"
 
 [dev-dependencies]
 rand = "0.8.5"
+
+[profile.release]
+strip = true
+opt-level = "s"
+lto = true
+panic = "abort"


### PR DESCRIPTION
> The opt-level setting controls the -C opt-level flag which controls the level of optimization.

"s": optimize for binary size

> The strip option controls the -C strip flag, which directs rustc to strip either symbols or debuginfo from a binary

strip = true is equivalent to strip = "symbols"

> The lto setting controls rustc’s -C lto, -C linker-plugin-lto, and -C embed-bitcode options, which control LLVM’s link time optimizations. LTO can produce better optimized code, using whole-program analysis, at the cost of longer linking time.

true or "fat": Performs “fat” LTO which attempts to perform optimizations across all crates within the dependency graph.

> The panic setting controls the -C panic flag which controls which panic strategy to use.

"abort": Terminate the process upon panic.

See https://doc.rust-lang.org/cargo/reference/profiles.html