### PR TITLE
Use panic::catch_unwind for safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,3 @@ rand = "0.8.5"
 strip = true
 opt-level = "s"
 lto = true
-panic = "abort"

--- a/src/ffi_bindings/mod.rs
+++ b/src/ffi_bindings/mod.rs
@@ -2,6 +2,7 @@ use crate::shell_injection::detect_shell_injection::detect_shell_injection_strin
 use crate::sql_injection::detect_sql_injection::detect_sql_injection_str;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
+use std::panic;
 use std::str;
 
 #[no_mangle]
@@ -9,23 +10,26 @@ pub extern "C" fn detect_shell_injection(
     command: *const c_char,
     userinput: *const c_char,
 ) -> c_int {
-    // Check if the pointers are null
-    if command.is_null() || userinput.is_null() {
-        eprintln!("Received null pointer for command or userinput.");
-        return 0; // Handle the error as needed
-    }
-    let command_bytes = unsafe { CStr::from_ptr(command).to_bytes() };
-    let userinput_bytes = unsafe { CStr::from_ptr(userinput).to_bytes() };
+    // Returns an integer value, representing a boolean (1 = true, 0 = false, 2 = error)
+    return panic::catch_unwind(|| {
+        // Check if the pointers are null
+        if command.is_null() || userinput.is_null() {
+            return 2;
+        }
 
-    let command_str = str::from_utf8(command_bytes).unwrap();
-    let userinput_str = str::from_utf8(userinput_bytes).unwrap();
+        let command_bytes = unsafe { CStr::from_ptr(command).to_bytes() };
+        let userinput_bytes = unsafe { CStr::from_ptr(userinput).to_bytes() };
 
-    // Returns an integer value, representing a boolean (1 = true, 0 = false).
-    if detect_shell_injection_stringified(command_str, userinput_str) {
-        1
-    } else {
-        0
-    }
+        let command_str = str::from_utf8(command_bytes).unwrap();
+        let userinput_str = str::from_utf8(userinput_bytes).unwrap();
+
+        if detect_shell_injection_stringified(command_str, userinput_str) {
+            return 1;
+        }
+
+        return 0;
+    })
+    .unwrap_or(2);
 }
 
 #[no_mangle]
@@ -34,21 +38,24 @@ pub extern "C" fn detect_sql_injection(
     userinput: *const c_char,
     dialect: c_int,
 ) -> c_int {
-    // Check if the pointers are null
-    if query.is_null() || userinput.is_null() {
-        eprintln!("Received null pointer for command or userinput.");
-        return 0; // Handle the error as needed
-    }
-    let query_bytes = unsafe { CStr::from_ptr(query).to_bytes() };
-    let userinput_bytes = unsafe { CStr::from_ptr(userinput).to_bytes() };
+    // Returns an integer value, representing a boolean (1 = true, 0 = false, 2 = error)
+    return panic::catch_unwind(|| {
+        // Check if the pointers are null
+        if query.is_null() || userinput.is_null() {
+            return 2;
+        }
 
-    let query_str = str::from_utf8(query_bytes).unwrap();
-    let userinput_str = str::from_utf8(userinput_bytes).unwrap();
+        let query_bytes = unsafe { CStr::from_ptr(query).to_bytes() };
+        let userinput_bytes = unsafe { CStr::from_ptr(userinput).to_bytes() };
 
-    // Returns an integer value, representing a boolean (1 = true, 0 = false).
-    if detect_sql_injection_str(query_str, userinput_str, dialect) {
-        1
-    } else {
-        0
-    }
+        let query_str = str::from_utf8(query_bytes).unwrap();
+        let userinput_str = str::from_utf8(userinput_bytes).unwrap();
+
+        if detect_sql_injection_str(query_str, userinput_str, dialect) {
+            return 1;
+        }
+
+        return 0;
+    })
+    .unwrap_or(2);
 }


### PR DESCRIPTION
Return 2 if an error occurs so that we can log this in Python, Ruby, ...

We need to remove panic = "abort" in the release profile

> This function only catches unwinding panics, not those that abort the process.