### PR TITLE
Use ubuntu-20.04 for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
     needs:
       - tests
       - lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     needs:
       - tests
       - lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
> Failed to load zen-internals library from '/opt/aikido-1.0.90/libzen_internals_x86_64-unknown-linux-gnu.so' with error /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/aikido-1.0.90/libzen_internals_x86_64-unknown-linux-gnu.so)!`