### PR TITLE
Use rev to pin SQL parser to a specific version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 oxc = "0.38.0"
 regex = "1.10.6"
-sqlparser = { git = "https://github.com/AikidoSec/datafusion-sqlparser-rs.git", branch = "main" }
+sqlparser = { git = "https://github.com/AikidoSec/datafusion-sqlparser-rs.git", rev = "3fb8f4be8481d278e874717dd2b86600e139e9ff" }
 url = "2.5.2"
 wasm-bindgen = "0.2"
 


### PR DESCRIPTION
Otherwise it's not very obvious that the parser has been updated

Also, you need to force a cargo update to get the updated parser