### PR TITLE
Don't use generic dialect as fallback if tokenizer failed

### DIFF
--- a/src/sql_injection/detect_sql_injection.rs
+++ b/src/sql_injection/detect_sql_injection.rs
@@ -2,7 +2,6 @@ use super::have_comments_changed::have_comments_changed;
 use super::is_common_sql_string::is_common_sql_string;
 use super::tokenize_query::tokenize_query;
 use crate::diff_in_vec_len;
-use sqlparser::tokenizer::Token;
 
 const SPACE_CHAR: char = ' ';
 

--- a/src/sql_injection/detect_sql_injection.rs
+++ b/src/sql_injection/detect_sql_injection.rs
@@ -20,7 +20,7 @@ pub fn detect_sql_injection_str(query: &str, userinput: &str, dialect: i32) -> b
     }
 
     // Tokenize query :
-    let tokens = tokenize_with_fallback(query, dialect);
+    let tokens = tokenize_query(query, dialect);
     if tokens.len() <= 0 {
         // Tokens are empty, probably a parsing issue with original query, return false.
         return false;
@@ -38,7 +38,7 @@ pub fn detect_sql_injection_str(query: &str, userinput: &str, dialect: i32) -> b
     // Replace user input with string of equal length and tokenize again :
     let safe_replace_str = "a".repeat(trimmed_userinput.len());
     let query_without_input: &str = &query.replace(trimmed_userinput, safe_replace_str.as_str());
-    let tokens_without_input = tokenize_with_fallback(query_without_input, dialect);
+    let tokens_without_input = tokenize_query(query_without_input, dialect);
 
     // Check delta for both comment tokens and all tokens in general :
     if diff_in_vec_len!(tokens, tokens_without_input) {
@@ -54,14 +54,4 @@ pub fn detect_sql_injection_str(query: &str, userinput: &str, dialect: i32) -> b
     }
 
     return false;
-}
-
-fn tokenize_with_fallback(query: &str, dialect: i32) -> Vec<Token> {
-    let query_tokens = tokenize_query(query, dialect);
-    if query_tokens.len() <= 0 && dialect != 0 {
-        // Dialect is not generic and query_tokens are empty, make fallback
-        return tokenize_query(query, 0);
-    }
-
-    return query_tokens;
 }

--- a/src/sql_injection/detect_sql_injection_test.rs
+++ b/src/sql_injection/detect_sql_injection_test.rs
@@ -8,6 +8,7 @@ mod tests {
             "postgresql" => 9,
             "sqlite" => 12,
             "clickhouse" => 3,
+            "generic" => 0,
             _ => panic!("Unknown dialect"),
         }
     }
@@ -18,6 +19,7 @@ mod tests {
             dialect("postgresql"),
             dialect("sqlite"),
             dialect("clickhouse"),
+            dialect("generic"),
         ]
     }
 

--- a/src/sql_injection/detect_sql_injection_test.rs
+++ b/src/sql_injection/detect_sql_injection_test.rs
@@ -2,13 +2,40 @@
 mod tests {
     use crate::sql_injection::detect_sql_injection::detect_sql_injection_str;
 
+    fn dialect(s: &str) -> i32 {
+        match s {
+            "mysql" => 8,
+            "postgresql" => 9,
+            "sqlite" => 12,
+            "clickhouse" => 3,
+            _ => panic!("Unknown dialect"),
+        }
+    }
+
+    fn get_supported_dialects() -> Vec<i32> {
+        vec![
+            dialect("mysql"),
+            dialect("postgresql"),
+            dialect("sqlite"),
+            dialect("clickhouse"),
+        ]
+    }
+
     macro_rules! is_injection {
         ($query:expr, $input:expr) => {
-            assert!(detect_sql_injection_str(
-                &$query.to_lowercase(),
-                &$input.to_lowercase(),
-                0
-            ))
+            for dia in get_supported_dialects().iter() {
+                assert!(
+                    detect_sql_injection_str(
+                        &$query.to_lowercase(),
+                        &$input.to_lowercase(),
+                        dia.clone()
+                    ),
+                    "should be an injection\nquery: {}\ninput: {}\ndialect: {}\n",
+                    $query,
+                    $input,
+                    dia.clone()
+                )
+            }
         };
         ($query:expr, $input:expr, $dialect:expr) => {
             assert!(detect_sql_injection_str(
@@ -20,11 +47,19 @@ mod tests {
     }
     macro_rules! not_injection {
         ($query:expr, $input:expr) => {
-            assert!(!detect_sql_injection_str(
-                &$query.to_lowercase(),
-                &$input.to_lowercase(),
-                0
-            ))
+            for dia in get_supported_dialects().iter() {
+                assert!(
+                    !detect_sql_injection_str(
+                        &$query.to_lowercase(),
+                        &$input.to_lowercase(),
+                        dia.clone()
+                    ),
+                    "should not be an injection\nquery: {}\ninput: {}\ndialect: {}\n",
+                    $query,
+                    $input,
+                    dia.clone()
+                )
+            }
         };
         ($query:expr, $input:expr, $dialect:expr) => {
             assert!(!detect_sql_injection_str(
@@ -35,28 +70,22 @@ mod tests {
         };
     }
 
-    fn dialect(s: &str) -> i32 {
-        match s {
-            "mysql" => 8,
-            "postgresql" => 9,
-            "sqlite" => 12,
-            _ => panic!("Unknown dialect"),
-        }
-    }
-
     #[test]
     fn test_postgres_dollar_signs() {
         not_injection!(
             "SELECT * FROM users WHERE id = $$' OR 1=1 -- $$",
-            "' OR 1=1 -- "
+            "' OR 1=1 -- ",
+            dialect("postgresql")
         );
         not_injection!(
             "SELECT * FROM users WHERE id = $$1; DROP TABLE users; -- $$",
-            "1; DROP TABLE users; -- "
+            "1; DROP TABLE users; -- ",
+            dialect("postgresql")
         );
         is_injection!(
             "SELECT * FROM users WHERE id = $$1$$ OR 1=1 -- $$",
-            "1$$ OR 1=1 -- "
+            "1$$ OR 1=1 -- ",
+            dialect("postgresql")
         );
     }
 
@@ -64,15 +93,18 @@ mod tests {
     fn test_postgres_dollar_named_dollar_signs() {
         not_injection!(
             "SELECT * FROM users WHERE id = $name$' OR 1=1 -- $name$",
-            "' OR 1=1 -- "
+            "' OR 1=1 -- ",
+            dialect("postgresql")
         );
         not_injection!(
             "SELECT * FROM users WHERE id = $name$1; DROP TABLE users; -- $name$",
-            "1; DROP TABLE users; -- "
+            "1; DROP TABLE users; -- ",
+            dialect("postgresql")
         );
         is_injection!(
             "SELECT * FROM users WHERE id = $name$1$name$ OR 1=1 -- $name$",
-            "1$name$ OR 1=1 -- "
+            "1$name$ OR 1=1 -- ",
+            dialect("postgresql")
         );
     }
 


### PR DESCRIPTION
It's better to be as strict as possible. Let's still allow generic dialect (e.g. for sinks like Prisma).