### PR TITLE
Handle Clickhouse queries with other statements being invalid

### DIFF
--- a/src/sql_injection/detect_sql_injection.rs
+++ b/src/sql_injection/detect_sql_injection.rs
@@ -19,26 +19,38 @@ pub fn detect_sql_injection_str(query: &str, userinput: &str, dialect: i32) -> b
         return false;
     }
 
+    // Remove leading and trailing spaces from user input
+    let trimmed_userinput = userinput.trim_matches(SPACE_CHAR);
+
+    if trimmed_userinput.len() <= 1 {
+        // If the trimmed user input is one character or empty, no injection took place.
+        return false;
+    }
+
     // Tokenize query :
     let tokens = tokenize_with_fallback(query, dialect);
     if tokens.len() <= 0 {
+        if dialect == 3 && query.contains(';') && has_multiple_statements(query, dialect) {
+            // Clickhouse does not support multiple statements
+            // The first statement will still be executed if of the other statements is still valid
+            // We'll assume the original query is valid
+            // If the query with user input replaced is valid, we'll assume it's an injection because it created a new statement
+            let query_without_input = replace_user_input_with_safe_str(query, userinput);
+            let tokens_without_input =
+                tokenize_with_fallback(query_without_input.as_str(), dialect);
+
+            if tokens_without_input.len() > 0 {
+                return true;
+            }
+        }
+
         // Tokens are empty, probably a parsing issue with original query, return false.
         return false;
     }
 
-    // Remove leading and trailing spaces from userinput :
-    let trimmed_userinput = userinput.trim_matches(SPACE_CHAR);
-
-    // Tokenize query without user input :
-    if trimmed_userinput.len() <= 1 {
-        // If the trimmed userinput is one character or empty, no injection took place.
-        return false;
-    }
-
     // Replace user input with string of equal length and tokenize again :
-    let safe_replace_str = "a".repeat(trimmed_userinput.len());
-    let query_without_input: &str = &query.replace(trimmed_userinput, safe_replace_str.as_str());
-    let tokens_without_input = tokenize_with_fallback(query_without_input, dialect);
+    let query_without_input = replace_user_input_with_safe_str(query, userinput);
+    let tokens_without_input = tokenize_with_fallback(query_without_input.as_str(), dialect);
 
     // Check delta for both comment tokens and all tokens in general :
     if diff_in_vec_len!(tokens, tokens_without_input) {
@@ -54,6 +66,38 @@ pub fn detect_sql_injection_str(query: &str, userinput: &str, dialect: i32) -> b
     }
 
     return false;
+}
+
+fn has_multiple_statements(query: &str, dialect: i32) -> bool {
+    assert!(query.contains(';'));
+
+    for (i, c) in query.char_indices() {
+        if c == ';' {
+            let statement = &query[..i + 1];
+            let tokens_stripped = tokenize_with_fallback(statement, dialect);
+            if tokens_stripped.len() > 0 {
+                if let Some(Token::SemiColon) = tokens_stripped.last() {
+                    let remaining = &query[i + 1..];
+
+                    if remaining.trim().len() <= 0 {
+                        return false;
+                    }
+
+                    return true;
+                    //return tokenize_query(remaining, dialect).len() <= 0;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+fn replace_user_input_with_safe_str(query: &str, user_input: &str) -> String {
+    let trimmed_user_input = user_input.trim_matches(SPACE_CHAR);
+    let safe_replace_str = "a".repeat(trimmed_user_input.len());
+
+    query.replace(trimmed_user_input, safe_replace_str.as_str())
 }
 
 fn tokenize_with_fallback(query: &str, dialect: i32) -> Vec<Token> {


### PR DESCRIPTION
If the original query is

```
insert into cats (name) values (' + var + ');
```

And the user input is

```
foo'||version());
```

Then the query will be

```sql
insert into cats_table (id, petname) values (null, 'foo'||version());');
```

Which isn't a valid query. The second statement is `');`

Clickhouse seems to ignore this because it does not allow multiple statements. It will still execute the first part so we need to detect this.