### PR TITLE
Enable bulk memory for wasm-opt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ benchmarking = []
 members = [
     "benchmarks",
 ]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory"]


### PR DESCRIPTION
```
[INFO]: Optimizing wasm binaries with `wasm-opt`... [wasm-validator error in function 0] unexpected false: Bulk memory operations require bulk memory [--enable-bulk-memory], on (memory.copy
 (i32.add
  (local.get $4)
  (i32.const 2128)
 )
 (i32.or
  (i32.add
   (local.get $4)
   (i32.const 2560)
  )
  (i32.const 7)
 )
 (i32.const 73)
)
```