### PR TITLE
Allow alpha followed by =

### DIFF
--- a/src/sql_injection/detect_sql_injection_test.rs
+++ b/src/sql_injection/detect_sql_injection_test.rs
@@ -767,6 +767,15 @@ mod tests {
     }
 
     #[test]
+    fn test_e_equal() {
+        not_injection!(
+            "select column form table where table.a = 1 AND table.active= 1",
+            "e=",
+            dialect("mysql")
+        );
+    }
+
+    #[test]
     fn test_mysql_string_escape_constant() {
         is_injection!(
             "insert into cats(a,b,c) values ('foo'),((select e'\\u' from (select version() as e from dual) x)),('bar');",

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -36,6 +36,21 @@ pub fn is_common_sql_string(user_input: &str) -> bool {
         return true;
     }
 
+    // e.g. SELECT * FROM users WHERE users.active= 1
+    // If the payload is `e=` the replaced query will be
+    // SELECT * FROM users WHERE users.activaa 1
+    // The structure of the query will not be the same
+    // it's very difficult to exploit a query using just "e=" as the user input.
+    let alpha_followed_by_equal: Regex = Regex::new(r"(?i)^[a-z]=*$").unwrap();
+
+    if user_input.len() == 2
+        && user_input.ends_with("=")
+        && alpha_followed_by_equal.is_match(user_input)
+    {
+        // If the user input is just a single letter followed by an equal sign, it's not an injection.
+        return false;
+    }
+
     if user_input.contains("asc") || user_input.contains("desc") {
         // Check if the user input is a common SQL pattern like "column_name ASC"
         // e.g. https://ghost.org/docs/content-api/#order (Ghost validates the order parameter)

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -41,14 +41,14 @@ pub fn is_common_sql_string(user_input: &str) -> bool {
     // SELECT * FROM users WHERE users.activaa 1
     // The structure of the query will not be the same
     // it's very difficult to exploit a query using just "e=" as the user input.
-    let alpha_followed_by_equal: Regex = Regex::new(r"(?i)^[a-z]=*$").unwrap();
+    let alpha_followed_by_equal: Regex = Regex::new(r"(?i)^[a-z]=$").unwrap();
 
     if user_input.len() == 2
         && user_input.ends_with("=")
         && alpha_followed_by_equal.is_match(user_input)
     {
         // If the user input is just a single letter followed by an equal sign, it's not an injection.
-        return false;
+        return true;
     }
 
     if user_input.contains("asc") || user_input.contains("desc") {


### PR DESCRIPTION
query
```sql
SELECT * FROM table WHERE table.active= 1
```

payload
```e=```

will alter the token structure after replacing with safe string "aa":
```sql
SELECT * FROM table WHERE table.activaa 1
```

So it will be flagged as a SQL injection, in general just using `e=` as payload will be very difficult to exploit. (as the generated SQL query should still be valid)