### PR TITLE
Set codegen-units = 1 for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ wasm-bindgen = "0.2"
 strip = true
 opt-level = "s"
 lto = true
+codegen-units = 1
 
 [features]
 benchmarking = []


### PR DESCRIPTION
Setting `codegen-units` to 1 to reduce size of release binaries. Also, potentially better performance.

**Example improvements for some targets from building locally:**
| Target | Before | After |
|--------|--------|-------|
| **WASM** | 2.5MB | 2.0MB |
| **Darwin ARM64** | 3.6MB | 2.7MB |
| **Linux ARM64** | 4.1MB | 3.1MB |


