### PR TITLE
Allow simple strings with trailing comma

### DIFF
--- a/src/sql_injection/detect_sql_injection_test.rs
+++ b/src/sql_injection/detect_sql_injection_test.rs
@@ -1095,6 +1095,39 @@ mod tests {
     }
 
     #[test]
+    fn test_trailing_comma() {
+        not_injection!(
+            "SELECT id, username, email FROM users WHERE id IN (1,2,3)",
+            "username,"
+        );
+        not_injection!(
+            "SELECT id, username, email FROM users WHERE id IN (1,2,3)",
+            "id,"
+        );
+        not_injection!(
+            "SELECT id, username, email FROM users WHERE id IN (1,2,3)",
+            "email"
+        );
+        not_injection!(
+            "SELECT id, username, email FROM users WHERE id IN (1,2,3)",
+            "email,"
+        );
+
+        is_injection!(
+            "SELECT id, username, email FROM users WHERE id IN (1,2,3)",
+            "username, email"
+        );
+        is_injection!(
+            "SELECT id, username, email FROM users WHERE id IN (1,2,3)",
+            "id, username"
+        );
+        is_injection!(
+            "SELECT id, username, email FROM users WHERE id IN (1,2,3)",
+            "username, email FROM"
+        );
+    }
+
+    #[test]
     fn test_time_zone() {
         not_injection!(
             r#"

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -153,7 +153,7 @@ pub fn is_common_sql_string(user_input: &str) -> bool {
     }
 
     // Allow strings with letters, digits and spaces that end with a comma,
-    if user_input.len() <= 200 && user_input.ends_with(',') {
+    if user_input.len() <= 40 && user_input.ends_with(',') {
         if regex!(r"^[a-z0-9 ]+,$").is_match(user_input) {
             return true;
         }

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -152,5 +152,12 @@ pub fn is_common_sql_string(user_input: &str) -> bool {
         return true;
     }
 
+    // Allow strings with letters, digits and spaces that end with a comma,
+    if user_input.len() <= 200 && user_input.ends_with(',') {
+        if regex!(r"^[a-z0-9 ]+,$").is_match(user_input) {
+            return true;
+        }
+    }
+
     return false;
 }

--- a/src/sql_injection/is_common_sql_string_test.rs
+++ b/src/sql_injection/is_common_sql_string_test.rs
@@ -420,5 +420,10 @@ mod tests {
         assert_eq!(is_common_sql_string(",,username"), false);
         assert_eq!(is_common_sql_string(",username"), false);
         assert_eq!(is_common_sql_string(",user name"), false);
+
+        let at_limit = format!("{},", "a".repeat(39));
+        assert_eq!(is_common_sql_string(&at_limit), true);
+        let over_limit = format!("{}a,", "a".repeat(39));
+        assert_eq!(is_common_sql_string(&over_limit), false);
     }
 }

--- a/src/sql_injection/is_common_sql_string_test.rs
+++ b/src/sql_injection/is_common_sql_string_test.rs
@@ -405,4 +405,20 @@ mod tests {
             false
         );
     }
+
+    #[test]
+    fn test_trailing_comma() {
+        assert_eq!(is_common_sql_string("username,"), true);
+        assert_eq!(is_common_sql_string("user name,"), true);
+
+        assert_eq!(is_common_sql_string(",username,"), false);
+        assert_eq!(is_common_sql_string("user,name,"), false);
+        assert_eq!(is_common_sql_string(",user,name"), false);
+        assert_eq!(is_common_sql_string("user,name"), false);
+        assert_eq!(is_common_sql_string(",user name,"), false);
+        assert_eq!(is_common_sql_string("username,,"), false);
+        assert_eq!(is_common_sql_string(",,username"), false);
+        assert_eq!(is_common_sql_string(",username"), false);
+        assert_eq!(is_common_sql_string(",user name"), false);
+    }
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Allowed short alphanumeric space-terminated strings that end with a comma.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/102237099?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->