### PR TITLE
Fix publish workflow for immutable releases and IP allowlist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 name: 🚀 Build Release Artifacts
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: write
@@ -201,27 +202,32 @@ jobs:
 
   upload-release-assets:
     needs: [build, build-wasm-node]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    runs-on: open-source-releaser
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: ./artifacts
 
-      - name: Upload all assets to release
-        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
-        with:
-          files: |
-            ./artifacts/linux-binaries/*
-            ./artifacts/linux-binaries-musl/*
-            ./artifacts/linux-binaries-arm64/*
-            ./artifacts/linux-binaries-arm64-musl/*
-            ./artifacts/windows-binaries/*
-            ./artifacts/windows-binaries-arm/*
-            ./artifacts/mac-binaries/*
-            ./artifacts/mac-binaries-arm64/*
-            ./artifacts/wasm-node-binaries/*
-            ./artifacts/wasm-binaries/*
+      - name: Create draft release and upload assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          if ! gh release view "$VERSION" &>/dev/null; then
+            gh release create "$VERSION" --draft --title "$VERSION" --generate-notes
+          fi
+          gh release upload "$VERSION" --clobber \
+            ./artifacts/linux-binaries/* \
+            ./artifacts/linux-binaries-musl/* \
+            ./artifacts/linux-binaries-arm64/* \
+            ./artifacts/linux-binaries-arm64-musl/* \
+            ./artifacts/windows-binaries/* \
+            ./artifacts/windows-binaries-arm/* \
+            ./artifacts/mac-binaries/* \
+            ./artifacts/mac-binaries-arm64/* \
+            ./artifacts/wasm-node-binaries/* \
+            ./artifacts/wasm-binaries/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -231,3 +231,5 @@ jobs:
             ./artifacts/mac-binaries-arm64/* \
             ./artifacts/wasm-node-binaries/* \
             ./artifacts/wasm-binaries/*
+          gh release edit "$VERSION" --draft=false
+


### PR DESCRIPTION
Trigger on tag push instead of release publish, create a draft release, and upload assets using gh CLI on the open-source-releaser runner. With immutable releases enabled, assets cannot be added after a release is published, so the workflow now creates a draft first.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Switched release trigger to tag pushes (v*), not release publish
* Created draft releases before uploading assets to support immutability

**🔧 Refactors**
* Replaced softprops action with gh CLI on open-source-releaser runner


<sup>[More info](https://app.aikido.dev/featurebranch/scan/102264862?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->