### PR TITLE
Move publish.yml write permissions to job level

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  packages: write
-  deployments: write
+  contents: read
 
 jobs:
   tests:
@@ -203,6 +201,8 @@ jobs:
   upload-release-assets:
     needs: [build, build-wasm-node]
     runs-on: open-source-releaser
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 3 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Moved repository write permissions from workflow to upload job.
* Changed top-level permissions to restrict contents access to read.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/129299645?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->