### PR TITLE
Allow unary +/- numbers in JS injection detection

### DIFF
--- a/src/js_injection/detect_js_injection_test.rs
+++ b/src/js_injection/detect_js_injection_test.rs
@@ -178,6 +178,21 @@ mod tests {
     }
 
     #[test]
+    fn test_js_allow_negative_number() {
+        not_injection!("const test = -10;", "-10", 0);
+        not_injection!("const test = +5;", "+5", 0);
+        not_injection!("const test = -3.14;", "-3.14", 0);
+        not_injection!("if (x > -10) { return true; }", "-10", 0);
+        not_injection!("const test = 1 + -2;", "1 + -2", 0);
+        // Still an injection: a negative number followed by injected code.
+        is_injection!(
+            "const test = -10; console.log('injected'); //;",
+            "-10; console.log('injected'); //",
+            0
+        );
+    }
+
+    #[test]
     fn test_js_real_cve() {
         // CVE-2024-21511
         is_injection!(

--- a/src/js_injection/is_safe_js_input.rs
+++ b/src/js_injection/is_safe_js_input.rs
@@ -1,11 +1,11 @@
 use oxc::allocator::Allocator;
-use oxc::ast::ast::BinaryOperator;
+use oxc::ast::ast::{BinaryOperator, UnaryOperator};
 use oxc::ast::AstKind;
 use oxc::parser::{ParseOptions, Parser};
 use oxc::span::SourceType;
 use oxc_ast_visit::Visit;
 
-// Safe operators
+// Safe binary operators
 const SAFE_OPERATORS: [BinaryOperator; 6] = [
     BinaryOperator::Addition,
     BinaryOperator::Subtraction,
@@ -14,6 +14,10 @@ const SAFE_OPERATORS: [BinaryOperator; 6] = [
     BinaryOperator::Exponential,
     BinaryOperator::Remainder,
 ];
+
+// Safe unary operators (e.g. negative/positive numbers like -10, +5)
+const SAFE_UNARY_OPERATORS: [UnaryOperator; 2] =
+    [UnaryOperator::UnaryNegation, UnaryOperator::UnaryPlus];
 
 pub fn is_safe_js_input(user_input: &str, allocator: &Allocator, source_type: SourceType) -> bool {
     let parser_result = Parser::new(&allocator, &user_input, source_type)
@@ -57,6 +61,12 @@ impl<'a> Visit<'a> for ASTPass {
             AstKind::BinaryExpression(b) => {
                 // Check if the binary operator is safe
                 if !SAFE_OPERATORS.contains(&b.operator) {
+                    self.contains_only_safe_tokens = false;
+                }
+            }
+            // Check if unary operator is allowed (e.g. -10, +5)
+            AstKind::UnaryExpression(u) => {
+                if !SAFE_UNARY_OPERATORS.contains(&u.operator) {
                     self.contains_only_safe_tokens = false;
                 }
             }

--- a/src/js_injection/is_safe_js_input_test.rs
+++ b/src/js_injection/is_safe_js_input_test.rs
@@ -31,6 +31,14 @@ mod tests {
         is_safe!("(1 + 2) * 3", &allocator, source_type);
         is_safe!("1e3 + 2e3", &allocator, source_type);
         is_safe!("1, 2", &allocator, source_type);
+        // Unary plus/minus on numbers
+        is_safe!("-10", &allocator, source_type);
+        is_safe!("+5", &allocator, source_type);
+        is_safe!("-3.14", &allocator, source_type);
+        is_safe!("-1e3", &allocator, source_type);
+        is_safe!("1 + -2", &allocator, source_type);
+        is_safe!("-(1 + 2)", &allocator, source_type);
+        is_safe!("- -10", &allocator, source_type);
     }
 
     #[test]
@@ -60,5 +68,15 @@ mod tests {
         is_unsafe!("new Test()", &allocator, source_type);
         is_unsafe!("'use strict';", &allocator, source_type);
         is_unsafe!("process.env", &allocator, source_type);
+        // Unsafe unary operators
+        is_unsafe!("!x", &allocator, source_type);
+        is_unsafe!("~10", &allocator, source_type);
+        is_unsafe!("typeof x", &allocator, source_type);
+        is_unsafe!("void 0", &allocator, source_type);
+        is_unsafe!("delete obj.x", &allocator, source_type);
+        // Safe unary operator but unsafe operand
+        is_unsafe!("-x", &allocator, source_type);
+        is_unsafe!("-alert()", &allocator, source_type);
+        is_unsafe!("-process.env", &allocator, source_type);
     }
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Allowed unary plus/minus numeric literals in JS safety checks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/131892196?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->