### PR TITLE
Fix typo

### DIFF
--- a/src/ffi_bindings/mod.rs
+++ b/src/ffi_bindings/mod.rs
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn detect_js_injection(
 
 /// Allocates memory in WASM linear memory
 ///
-/// # Satefy
+/// # Safety
 ///
 /// The returned pointer must be deallocated using `wasm_free` with the exact same size.
 /// The allocated memory is uninitialized.
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn wasm_alloc(size: usize) -> *mut u8 {
 
 /// Deallocates memory previously allocated by `wasm_alloc`
 ///
-/// # Satefy
+/// # Safety
 ///
 /// - `ptr` must have been allocated by `wasm_alloc`
 /// - `size` must be the exact size passed to `wasm_alloc`


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Corrected 'Satefy' typos to 'Safety' in WASM allocation comments


<sup>[More info](https://app.aikido.dev/featurebranch/scan/133654692?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->