### PR TITLE
Fix all clippy warnings in lib

### DIFF
--- a/src/ffi_bindings/mod.rs
+++ b/src/ffi_bindings/mod.rs
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn detect_sql_injection(
     dialect: c_int,
 ) -> c_int {
     // Returns an integer value, representing a boolean (1 = true, 0 = false, 2 = error)
-    return panic::catch_unwind(|| {
+    panic::catch_unwind(|| {
         // Check if the pointers are null
         if query.is_null() || userinput.is_null() {
             return 2;
@@ -60,9 +60,10 @@ pub unsafe extern "C" fn detect_sql_injection(
         if detection_results.detected {
             return 1;
         }
-        return 0;
+
+        0
     })
-    .unwrap_or(2);
+    .unwrap_or(2)
 }
 
 /// # Safety
@@ -78,7 +79,7 @@ pub unsafe extern "C" fn detect_js_injection(
     sourcetype: c_int,
 ) -> c_int {
     // Returns an integer value, representing a boolean (1 = true, 0 = false, 2 = error)
-    return panic::catch_unwind(|| {
+    panic::catch_unwind(|| {
         // Check if the pointers are null
         if code.is_null() || userinput.is_null() {
             return 2;
@@ -106,9 +107,9 @@ pub unsafe extern "C" fn detect_js_injection(
             return 1;
         }
 
-        return 0;
+        0
     })
-    .unwrap_or(2);
+    .unwrap_or(2)
 }
 
 /// Allocates memory in WASM linear memory

--- a/src/js_injection/detect_js_injection.rs
+++ b/src/js_injection/detect_js_injection.rs
@@ -37,7 +37,7 @@ pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> 
         })
         .parse();
 
-    if parser_result.panicked || parser_result.errors.len() > 0 {
+    if parser_result.panicked || !parser_result.errors.is_empty() {
         return false;
     }
 
@@ -51,7 +51,7 @@ pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> 
         })
         .parse();
 
-    if parser_result_without_input.panicked || parser_result_without_input.errors.len() > 0 {
+    if parser_result_without_input.panicked || !parser_result_without_input.errors.is_empty() {
         // Try to parse by replacing the user input with a empty string.
         code_without_input = code.replace(userinput, "");
 
@@ -62,7 +62,7 @@ pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> 
             })
             .parse();
 
-        if parser_result_without_input.panicked || parser_result_without_input.errors.len() > 0 {
+        if parser_result_without_input.panicked || !parser_result_without_input.errors.is_empty() {
             return false;
         }
     }

--- a/src/js_injection/detect_js_injection.rs
+++ b/src/js_injection/detect_js_injection.rs
@@ -30,7 +30,7 @@ pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> 
         return false;
     }
 
-    let parser_result = Parser::new(&allocator, &code, source_type)
+    let parser_result = Parser::new(&allocator, code, source_type)
         .with_options(ParseOptions {
             allow_return_outside_function: true,
             ..ParseOptions::default()

--- a/src/js_injection/detect_js_injection.rs
+++ b/src/js_injection/detect_js_injection.rs
@@ -83,5 +83,5 @@ pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> 
         return true;
     }
 
-    return false;
+    false
 }

--- a/src/js_injection/have_comments_changed.rs
+++ b/src/js_injection/have_comments_changed.rs
@@ -21,5 +21,5 @@ pub fn have_comments_changed(comments1: &Vec<Comment>, comments2: &Vec<Comment>)
         }
     }
 
-    return false;
+    false
 }

--- a/src/js_injection/have_statements_changed.rs
+++ b/src/js_injection/have_statements_changed.rs
@@ -27,7 +27,7 @@ fn get_ast_kind_tokens<'a>(
     let mut ast_pass = ASTPass {
         tokens: Vec::new_in(allocator),
     };
-    ast_pass.visit_program(&program);
+    ast_pass.visit_program(program);
     return ast_pass.tokens;
 }
 

--- a/src/js_injection/have_statements_changed.rs
+++ b/src/js_injection/have_statements_changed.rs
@@ -17,7 +17,7 @@ pub fn have_statements_changed(
         return true;
     }
 
-    return false;
+    false
 }
 
 fn get_ast_kind_tokens<'a>(
@@ -28,7 +28,8 @@ fn get_ast_kind_tokens<'a>(
         tokens: Vec::new_in(allocator),
     };
     ast_pass.visit_program(program);
-    return ast_pass.tokens;
+
+    ast_pass.tokens
 }
 
 struct ASTPass<'a> {

--- a/src/js_injection/is_safe_js_input.rs
+++ b/src/js_injection/is_safe_js_input.rs
@@ -36,7 +36,7 @@ pub fn is_safe_js_input(user_input: &str, allocator: &Allocator, source_type: So
     };
     ast_pass.visit_program(&parser_result.program);
 
-    return ast_pass.contains_only_safe_tokens;
+    ast_pass.contains_only_safe_tokens
 }
 
 struct ASTPass {

--- a/src/js_injection/is_safe_js_input.rs
+++ b/src/js_injection/is_safe_js_input.rs
@@ -20,7 +20,7 @@ const SAFE_UNARY_OPERATORS: [UnaryOperator; 2] =
     [UnaryOperator::UnaryNegation, UnaryOperator::UnaryPlus];
 
 pub fn is_safe_js_input(user_input: &str, allocator: &Allocator, source_type: SourceType) -> bool {
-    let parser_result = Parser::new(&allocator, &user_input, source_type)
+    let parser_result = Parser::new(allocator, user_input, source_type)
         .with_options(ParseOptions {
             allow_return_outside_function: true,
             ..ParseOptions::default()

--- a/src/js_injection/is_safe_js_input.rs
+++ b/src/js_injection/is_safe_js_input.rs
@@ -27,7 +27,7 @@ pub fn is_safe_js_input(user_input: &str, allocator: &Allocator, source_type: So
         })
         .parse();
 
-    if parser_result.panicked || parser_result.errors.len() > 0 {
+    if parser_result.panicked || !parser_result.errors.is_empty() {
         return false;
     }
 
@@ -53,7 +53,7 @@ impl<'a> Visit<'a> for ASTPass {
             | AstKind::SequenceExpression(_) => {} // Allow sequences, like 1, 2, 3
             // Check if program comments, directives or hashbang are present
             AstKind::Program(p) => {
-                if p.comments.len() > 0 || p.directives.len() > 0 || p.hashbang.is_some() {
+                if !p.comments.is_empty() || !p.directives.is_empty() || p.hashbang.is_some() {
                     self.contains_only_safe_tokens = false;
                 }
             }

--- a/src/sql_injection/detect_sql_injection.rs
+++ b/src/sql_injection/detect_sql_injection.rs
@@ -52,7 +52,7 @@ pub fn detect_sql_injection_str(
 
     // Tokenize query :
     let tokens = tokenize_query(&query, dialect);
-    if tokens.len() <= 0 {
+    if tokens.is_empty() {
         // Tokens are empty, probably a parsing issue with original query, return false.
         return SqlInjectionDetectionResult {
             detected: false,

--- a/src/sql_injection/detect_sql_injection.rs
+++ b/src/sql_injection/detect_sql_injection.rs
@@ -96,8 +96,8 @@ pub fn detect_sql_injection_str(
         };
     }
 
-    return SqlInjectionDetectionResult {
+    SqlInjectionDetectionResult {
         detected: false,
         reason: DetectionReason::NoChangesFound,
-    };
+    }
 }

--- a/src/sql_injection/filter_for_comment_tokens.rs
+++ b/src/sql_injection/filter_for_comment_tokens.rs
@@ -12,11 +12,11 @@ pub fn filter_for_comment_tokens(tokens: Vec<Token>) -> Vec<Whitespace> {
         if let Token::Whitespace(whitespace) = token {
             // Token is whitespace, if this token is singleline comment or multiline,
             // Add to comments_vector.
-            let whitespace_is_comment = match whitespace {
-                Whitespace::SingleLineComment { .. } => true,
-                Whitespace::MultiLineComment(_) => true,
-                _ => false,
-            };
+            let whitespace_is_comment = matches!(
+                whitespace,
+                Whitespace::SingleLineComment { .. } | Whitespace::MultiLineComment(_),
+            );
+
             if whitespace_is_comment {
                 comments_vector.push(whitespace);
             }

--- a/src/sql_injection/filter_for_comment_tokens.rs
+++ b/src/sql_injection/filter_for_comment_tokens.rs
@@ -22,5 +22,6 @@ pub fn filter_for_comment_tokens(tokens: Vec<Token>) -> Vec<Whitespace> {
             }
         }
     }
-    return comments_vector;
+
+    comments_vector
 }

--- a/src/sql_injection/have_comments_changed.rs
+++ b/src/sql_injection/have_comments_changed.rs
@@ -34,7 +34,7 @@ pub fn have_comments_changed(tokens1: Vec<Token>, tokens2: Vec<Token>) -> bool {
         }
     }
 
-    return false;
+    false
 }
 
 /* Optimalization to keep in mind : We only check length of comments since in case of attack
@@ -59,7 +59,7 @@ fn comment_token_differs_from_singleline(
         return false;
     }
 
-    return true; // means this is another type
+    true // means this is another type
 }
 
 /* Optimalization to keep in mind : We only check length of comments since in case of attack
@@ -70,5 +70,6 @@ fn comment_token_differs_from_multiline(comment1: String, comment_token2: Whites
         // The length of both comments are not the same -> Strucutre is altered.
         return comment2.len().abs_diff(comment1.len()) != 0;
     }
-    return true; // So if it's a singleline whitespace for example.
+
+    true // So if it's a singleline whitespace for example.
 }

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -173,5 +173,5 @@ pub fn is_common_sql_string(user_input: &str) -> bool {
         return true;
     }
 
-    return false;
+    false
 }

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -102,31 +102,39 @@ pub fn is_common_sql_string(user_input: &str) -> bool {
     // example: SELECT * FROM users WHERE user_id = '${user id}' AND name = '${user_name}'
 
     // e.g. 'a or '1 or 'product-id-123
-    if user_input.starts_with("'") && user_input.len() <= 200 && !user_input.contains("--") {
-        if regex!(r"^'[a-z0-9-]+$").is_match(user_input) {
-            return true;
-        }
+    if user_input.starts_with("'")
+        && user_input.len() <= 200
+        && !user_input.contains("--")
+        && regex!(r"^'[a-z0-9-]+$").is_match(user_input)
+    {
+        return true;
     }
 
     // e.g. a' or 1' or product-id-123'
-    if user_input.ends_with("'") && user_input.len() <= 200 && !user_input.contains("--") {
-        if regex!(r"^[a-z0-9-]+'$").is_match(user_input) {
-            return true;
-        }
+    if user_input.ends_with("'")
+        && user_input.len() <= 200
+        && !user_input.contains("--")
+        && regex!(r"^[a-z0-9-]+'$").is_match(user_input)
+    {
+        return true;
     }
 
     // e.g. "a or "1 or "product-id-123
-    if user_input.starts_with("\"") && user_input.len() <= 200 && !user_input.contains("--") {
-        if regex!(r#"^"[a-z0-9-]+$"#).is_match(user_input) {
-            return true;
-        }
+    if user_input.starts_with("\"")
+        && user_input.len() <= 200
+        && !user_input.contains("--")
+        && regex!(r#"^"[a-z0-9-]+$"#).is_match(user_input)
+    {
+        return true;
     }
 
     // e.g. a" or 1" or product-id-123"
-    if user_input.ends_with("\"") && user_input.len() <= 200 && !user_input.contains("--") {
-        if regex!(r#"^[a-z0-9-]+"$"#).is_match(user_input) {
-            return true;
-        }
+    if user_input.ends_with("\"")
+        && user_input.len() <= 200
+        && !user_input.contains("--")
+        && regex!(r#"^[a-z0-9-]+"$"#).is_match(user_input)
+    {
+        return true;
     }
 
     if user_input.contains(".") {
@@ -158,10 +166,11 @@ pub fn is_common_sql_string(user_input: &str) -> bool {
     }
 
     // Allow strings with letters, digits and spaces that end with a comma,
-    if user_input.len() <= 40 && user_input.ends_with(',') {
-        if regex!(r"^[a-z0-9 ]+,$").is_match(user_input) {
-            return true;
-        }
+    if user_input.len() <= 40
+        && user_input.ends_with(',')
+        && regex!(r"^[a-z0-9 ]+,$").is_match(user_input)
+    {
+        return true;
     }
 
     return false;

--- a/src/sql_injection/tokenize_query.rs
+++ b/src/sql_injection/tokenize_query.rs
@@ -10,10 +10,5 @@ pub fn tokenize_query(sql: &str, dialect: i32) -> Vec<Token> {
     the escaping" ~ https://github.com/sqlparser-rs/sqlparser-rs/blob/main/src/tokenizer.rs#L591-L620
     */
     let mut tokenizer = Tokenizer::new(dialect.as_ref(), sql).with_unescape(false);
-    match tokenizer.tokenize() {
-        Ok(tokens) => tokens, // Return the tokens if successful
-        Err(_e) => {
-            Vec::new() // Return empty vector if unsuccessfull.
-        }
-    }
+    tokenizer.tokenize().unwrap_or_default()
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Replaced manual length checks and needless returns with idiomatic is_empty.
* Consolidated nested ifs and simplified multi-clause conditionals using single expressions.
* Replaced explicit match with unwrap_or_default for tokenizer error handling.
* Used matches! macro and removed unnecessary borrows to simplify code.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/133698950?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->