### PR TITLE
Improve JS injection detection performance

### DIFF
--- a/src/js_injection/detect_js_injection.rs
+++ b/src/js_injection/detect_js_injection.rs
@@ -75,11 +75,7 @@ pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> 
         return true;
     }
 
-    if have_statements_changed(
-        &parser_result.program,
-        &parser_result_without_input.program,
-        &allocator,
-    ) {
+    if have_statements_changed(&parser_result.program, &parser_result_without_input.program) {
         return true;
     }
 

--- a/src/js_injection/have_statements_changed.rs
+++ b/src/js_injection/have_statements_changed.rs
@@ -1,43 +1,23 @@
-use crate::diff_in_vec_len;
-use oxc::allocator::{Allocator, Vec};
 use oxc::ast::ast::Program;
 use oxc::ast::AstKind;
 use oxc_ast_visit::Visit;
 
-pub fn have_statements_changed(
-    program1: &Program,
-    program2: &Program,
-    allocator: &Allocator,
-) -> bool {
-    let tokens1 = get_ast_kind_tokens(program1, allocator);
-    let tokens2 = get_ast_kind_tokens(program2, allocator);
-
-    // If the number of tokens is different, it's an injection.
-    if diff_in_vec_len!(tokens1, tokens2) {
-        return true;
-    }
-
-    false
+pub fn have_statements_changed(program1: &Program, program2: &Program) -> bool {
+    count_ast_nodes(program1) != count_ast_nodes(program2)
 }
 
-fn get_ast_kind_tokens<'a>(
-    program: &'a Program<'a>,
-    allocator: &'a Allocator,
-) -> Vec<'a, AstKind<'a>> {
-    let mut ast_pass = ASTPass {
-        tokens: Vec::new_in(allocator),
-    };
-    ast_pass.visit_program(program);
-
-    ast_pass.tokens
+fn count_ast_nodes(program: &Program) -> usize {
+    let mut pass = ASTCounter { count: 0 };
+    pass.visit_program(program);
+    pass.count
 }
 
-struct ASTPass<'a> {
-    tokens: Vec<'a, AstKind<'a>>,
+struct ASTCounter {
+    count: usize,
 }
 
-impl<'a> Visit<'a> for ASTPass<'a> {
-    fn enter_node(&mut self, kind: AstKind<'a>) {
-        self.tokens.push(kind);
+impl<'a> Visit<'a> for ASTCounter {
+    fn enter_node(&mut self, _kind: AstKind<'a>) {
+        self.count += 1;
     }
 }

--- a/src/js_injection/is_safe_js_input.rs
+++ b/src/js_injection/is_safe_js_input.rs
@@ -20,6 +20,12 @@ const SAFE_UNARY_OPERATORS: [UnaryOperator; 2] =
     [UnaryOperator::UnaryNegation, UnaryOperator::UnaryPlus];
 
 pub fn is_safe_js_input(user_input: &str, allocator: &Allocator, source_type: SourceType) -> bool {
+    // Right now this function only returns true if the user input contains numbers
+    // This is a early return to avoid parsing the user input if it doesn't contain any numbers
+    if !user_input.bytes().any(|b| b.is_ascii_digit()) {
+        return false;
+    }
+
     let parser_result = Parser::new(allocator, user_input, source_type)
         .with_options(ParseOptions {
             allow_return_outside_function: true,
@@ -45,6 +51,10 @@ struct ASTPass {
 
 impl<'a> Visit<'a> for ASTPass {
     fn enter_node(&mut self, kind: AstKind<'a>) {
+        if !self.contains_only_safe_tokens {
+            // Early return if we already know the input might be unsafe, no need to check further nodes
+            return;
+        }
         match kind {
             // Allow without additional checks, all subnodes of the AST will still be checked, so e.g. a sequence of unsafe tokens will be caught
             AstKind::ExpressionStatement(_) // Allow expressions, this contains the more specific expression type, like BinaryExpression


### PR DESCRIPTION
# Changes

- Do not collect all AST nodes in a Vec just to count them in `have_statements_changed`. Use a counter instead.
- Early return in `is_safe_js_input` if input does not contain digits as only math is excluded here right now
- Add early return in `is_safe_js_input` if already non safe input was found

# Benchmark

| Benchmark        | main (avg) | branch (avg) | Delta      | Improvement |
| ---------------- | ---------- | ------------ | ---------- | ----------- |
| is injection     | 761.23 ns  | 583.52 ns    | -177.71 ns | **23.3%**  |
| is not injection | 740.56 ns  | 525.96 ns    | -214.60 ns | **29.0%**  |
| big code         | 181.39 µs  | 173.49 µs    | -7.90 µs   | **4.4%**   |



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced AST node collection with counter to reduce allocations
* Added early digit presence check to skip parsing non-numeric inputs
* Added early visitor exit when unsafe token was already detected

**🔧 Refactors**
* Removed allocator parameter from have_statements_changed and updated call sites


<sup>[More info](https://app.aikido.dev/featurebranch/scan/134189971?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->