### PR TITLE
Improve SQL detection performance

### DIFF
--- a/src/sql_injection/detect_sql_injection.rs
+++ b/src/sql_injection/detect_sql_injection.rs
@@ -50,16 +50,6 @@ pub fn detect_sql_injection_str(
         };
     }
 
-    // Tokenize query :
-    let tokens = tokenize_query(&query, dialect);
-    if tokens.is_empty() {
-        // Tokens are empty, probably a parsing issue with original query, return false.
-        return SqlInjectionDetectionResult {
-            detected: false,
-            reason: DetectionReason::FailedToTokenizeQuery,
-        };
-    }
-
     // Remove leading and trailing spaces from userinput :
     let trimmed_userinput = userinput.trim_matches(SPACE_CHAR);
 
@@ -69,6 +59,16 @@ pub fn detect_sql_injection_str(
         return SqlInjectionDetectionResult {
             detected: false,
             reason: DetectionReason::UserInputTooSmall,
+        };
+    }
+
+    // Tokenize query :
+    let tokens = tokenize_query(&query, dialect);
+    if tokens.is_empty() {
+        // Tokens are empty, probably a parsing issue with original query, return false.
+        return SqlInjectionDetectionResult {
+            detected: false,
+            reason: DetectionReason::FailedToTokenizeQuery,
         };
     }
 

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -41,9 +41,7 @@ macro_rules! regex {
 }
 
 pub fn is_common_sql_string(user_input: &str) -> bool {
-    let is_common_sql_string = COMMON_SQL_STRINGS
-        .iter()
-        .any(|&common_string| user_input == common_string);
+    let is_common_sql_string = COMMON_SQL_STRINGS.contains(&user_input);
 
     if is_common_sql_string {
         return true;

--- a/src/sql_injection/is_common_sql_string.rs
+++ b/src/sql_injection/is_common_sql_string.rs
@@ -2,33 +2,33 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 pub const COMMON_SQL_STRINGS: [&str; 28] = [
-    "SELECT *",
-    "SELECT COUNT(*)",
-    "INSERT INTO",
-    "INNER JOIN",
-    "LEFT JOIN",
-    "RIGHT JOIN",
-    "LEFT OUTER JOIN",
-    "RIGHT OUTER JOIN",
-    "DELETE FROM",
-    "ORDER BY",
-    "GROUP BY",
-    "ON CONFLICT",
-    "ON CONFLICT DO UPDATE",
-    "ON CONFLICT DO NOTHING",
-    "ON DUPLICATE KEY",
-    "ON DUPLICATE KEY UPDATE",
-    "DO UPDATE",
-    "DO NOTHING",
-    "COUNT(*)",
-    "IS NULL",
-    "IS NOT NULL",
-    "IS NOT",
-    "NOT EXISTS",
-    "DISTINCT ON",
+    "select *",
+    "select count(*)",
+    "insert into",
+    "inner join",
+    "left join",
+    "right join",
+    "left outer join",
+    "right outer join",
+    "delete from",
+    "order by",
+    "group by",
+    "on conflict",
+    "on conflict do update",
+    "on conflict do nothing",
+    "on duplicate key",
+    "on duplicate key update",
+    "do update",
+    "do nothing",
+    "count(*)",
+    "is null",
+    "is not null",
+    "is not",
+    "not exists",
+    "distinct on",
     "[]",
-    "NOT IN",
-    "TIME ZONE",
+    "not in",
+    "time zone",
     ".*",
 ];
 
@@ -43,8 +43,7 @@ macro_rules! regex {
 pub fn is_common_sql_string(user_input: &str) -> bool {
     let is_common_sql_string = COMMON_SQL_STRINGS
         .iter()
-        .map(|s| s.to_lowercase())
-        .any(|common_string| user_input == common_string);
+        .any(|&common_string| user_input == common_string);
 
     if is_common_sql_string {
         return true;

--- a/src/sql_injection/is_common_sql_string_test.rs
+++ b/src/sql_injection/is_common_sql_string_test.rs
@@ -4,6 +4,17 @@ mod tests {
     use crate::sql_injection::is_common_sql_string::COMMON_SQL_STRINGS;
 
     #[test]
+    fn common_sql_strings_are_lowercase() {
+        for s in COMMON_SQL_STRINGS {
+            assert_eq!(
+                s,
+                s.to_lowercase(),
+                "`{s}` is not lowercase; all entries in COMMON_SQL_STRINGS must be lowercase"
+            );
+        }
+    }
+
+    #[test]
     fn test_common_sql_strings() {
         COMMON_SQL_STRINGS.iter().for_each(|common_string| {
             assert!(


### PR DESCRIPTION
| Benchmark            | `main` avg | PR avg    | Speedup                    |
|----------------------|------------|-----------|----------------------------|
| sql/is injection     | 3.5370 µs  | 3.0797 µs | **12.9%** faster          |
| sql/is not injection | 519.02 ns  | 71.43 ns  | **86.2%** faster          |
| sql/big sql          | 888.81 µs  | 882.86 µs | **0.7%** (within noise)   |

- This is the average of 8 executions of the benchmark suite per branch.
- `is_common_sql_string` is not calling `to_lowercase` for each common string on each run
- the user input length check was moved before tokenizing the query

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Moved tokenization after input-length check to avoid unnecessary parsing.
* Replaced per-call lowercase mapping with direct contains check for performance.
* Normalized common SQL strings to lowercase and added additional patterns.

**🔧 Refactors**
* Lowercased query and user input at function start for consistency.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/136678239?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->