### PR TITLE
Remove old comment about lowercase

### DIFF
--- a/src/sql_injection/detect_sql_injection.rs
+++ b/src/sql_injection/detect_sql_injection.rs
@@ -24,7 +24,6 @@ pub enum DetectionReason {
     CommentStructureAltered,
 }
 
-// `userinput` and `query` provided to this function should already be lowercase.
 pub fn detect_sql_injection_str(
     query_raw: &str,
     userinput_raw: &str,


### PR DESCRIPTION
See https://github.com/AikidoSec/zen-internals/pull/107

We forgot to remove the comment!

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**📚 Documentation**
* Removed outdated comment about lowercase expectation in function


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137305466?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->