### PR TITLE
Fix JS injection detection with bare function expressions

### DIFF
--- a/src/js_injection/detect_js_injection.rs
+++ b/src/js_injection/detect_js_injection.rs
@@ -3,8 +3,25 @@ use super::have_statements_changed::have_statements_changed;
 use super::helpers::select_sourcetype_based_on_enum::select_sourcetype_based_on_enum;
 use super::is_safe_js_input::is_safe_js_input;
 use oxc::allocator::Allocator;
-use oxc::parser::{ParseOptions, Parser};
+use oxc::parser::{ParseOptions, Parser, ParserReturn};
 use oxc::span::SourceType;
+
+fn parse_js<'a>(
+    allocator: &'a Allocator,
+    code: &'a str,
+    source_type: SourceType,
+) -> ParserReturn<'a> {
+    Parser::new(allocator, code, source_type)
+        .with_options(ParseOptions {
+            allow_return_outside_function: true,
+            ..ParseOptions::default()
+        })
+        .parse()
+}
+
+fn parses_ok(result: &ParserReturn) -> bool {
+    !result.panicked && result.errors.is_empty()
+}
 
 pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> bool {
     if userinput.len() <= 1 {
@@ -30,39 +47,45 @@ pub fn detect_js_injection_str(code: &str, userinput: &str, sourcetype: i32) -> 
         return false;
     }
 
-    let parser_result = Parser::new(&allocator, code, source_type)
-        .with_options(ParseOptions {
-            allow_return_outside_function: true,
-            ..ParseOptions::default()
-        })
-        .parse();
+    let mut parser_result = parse_js(&allocator, code, source_type);
 
-    if parser_result.panicked || !parser_result.errors.is_empty() {
-        return false;
+    // Some code is only valid JS in an expression position, e.g. a bare
+    // `function() {}` passed as a value (as done with MongoDB)
+    // That's a syntax error as a standalone statement: "Function statements require a function name",
+    // so retry wrapped in parens.
+    // The closing paren goes on its own line so it isn't swallowed if the code ends in a `//` line comment.
+    let wrapped_code;
+    let mut wrap_in_parens = false;
+
+    if !parses_ok(&parser_result) {
+        wrapped_code = format!("({code}\n)");
+        let wrapped_result = parse_js(&allocator, &wrapped_code, source_type);
+
+        if !parses_ok(&wrapped_result) {
+            return false;
+        }
+        wrap_in_parens = true;
+        parser_result = wrapped_result;
     }
 
     let safe_replace_str = "a".repeat(userinput.len());
     let mut code_without_input: String = code.replace(userinput, &safe_replace_str);
+    if wrap_in_parens {
+        code_without_input = format!("({code_without_input}\n)");
+    }
 
-    let mut parser_result_without_input = Parser::new(&allocator, &code_without_input, source_type)
-        .with_options(ParseOptions {
-            allow_return_outside_function: true,
-            ..ParseOptions::default()
-        })
-        .parse();
+    let mut parser_result_without_input = parse_js(&allocator, &code_without_input, source_type);
 
-    if parser_result_without_input.panicked || !parser_result_without_input.errors.is_empty() {
+    if !parses_ok(&parser_result_without_input) {
         // Try to parse by replacing the user input with a empty string.
         code_without_input = code.replace(userinput, "");
+        if wrap_in_parens {
+            code_without_input = format!("({code_without_input}\n)");
+        }
 
-        parser_result_without_input = Parser::new(&allocator, &code_without_input, source_type)
-            .with_options(ParseOptions {
-                allow_return_outside_function: true,
-                ..ParseOptions::default()
-            })
-            .parse();
+        parser_result_without_input = parse_js(&allocator, &code_without_input, source_type);
 
-        if parser_result_without_input.panicked || !parser_result_without_input.errors.is_empty() {
+        if !parses_ok(&parser_result_without_input) {
             return false;
         }
     }

--- a/src/js_injection/detect_js_injection_test.rs
+++ b/src/js_injection/detect_js_injection_test.rs
@@ -302,4 +302,20 @@ mod tests {
             3
         );
     }
+
+    #[test]
+    fn test_bare_function_expression() {
+        not_injection!("function() { return 'Hello'; }", "Hello", 2);
+        is_injection!(
+            "function() { const test = 'Hello'; console.log('injection'); } //'; }",
+            "Hello'; console.log('injection'); } //",
+            2
+        );
+
+        not_injection!(
+            "function() { const test = 'Hello'; console.log('injection'); } //'; } }",
+            "Hello'; console.log('injection'); } //",
+            2
+        );
+    }
 }

--- a/src/js_injection/detect_js_injection_test.rs
+++ b/src/js_injection/detect_js_injection_test.rs
@@ -305,16 +305,25 @@ mod tests {
 
     #[test]
     fn test_bare_function_expression() {
+        // A bare `function() {}` is not valid as a standalone statement (it
+        // needs a name), but it's common as a value, e.g. a MongoDB $where function
         not_injection!("function() { return 'Hello'; }", "Hello", 2);
+        is_injection!("function() { return 'Hello'; } //';}", "Hello'; } //", 2);
+
+        // Same, but async and generator functions
+        not_injection!("async function() { return 'Hello'; }", "Hello", 2);
         is_injection!(
-            "function() { const test = 'Hello'; console.log('injection'); } //'; }",
-            "Hello'; console.log('injection'); } //",
+            "async function() { return 'Hello'; } //';}",
+            "Hello'; } //",
             2
         );
+        not_injection!("function*() { return 'Hello'; }", "Hello", 2);
+        is_injection!("function*() { return 'Hello'; } //';}", "Hello'; } //", 2);
 
+        // Invalid JS (missing closing brace) still isn't detected
         not_injection!(
-            "function() { const test = 'Hello'; console.log('injection'); } //'; } }",
-            "Hello'; console.log('injection'); } //",
+            "function() { return 'Hello'; console.log('injection'); //'",
+            "Hello'; console.log('injection'); //",
             2
         );
     }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed JS injection detection for bare function expressions by wrapping in parentheses

**🔧 Refactors**
* Extracted helper parse_js and parses_ok to reduce parser duplication


<sup>[More info](https://app.aikido.dev/featurebranch/scan/152669538?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->