### PR TITLE
Prevent WASM interpreter fallback on JVM

### DIFF
--- a/.github/workflows/jvm-wasm-compilation.yml
+++ b/.github/workflows/jvm-wasm-compilation.yml
@@ -1,0 +1,60 @@
+name: ☕ JVM WASM Compilation
+
+on:
+  workflow_call: {}
+  push: {}
+
+permissions:
+  contents: read
+
+env:
+  CHICORY_VERSION: 1.7.5
+  CHICORY_COMPILER_SHA256: ff2c00c6b9d5bb451b0d34e224c7d54985b8271b84cf0b8c52dd994ad0dcf86d
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+          rustup target add wasm32-unknown-unknown
+
+      - name: Set up Java
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Install Binaryen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binaryen
+
+      - name: Build WASM
+        run: ./scripts/build-wasm.sh
+
+      - name: Install Chicory compiler
+        run: |
+          curl --fail --location --silent --show-error \
+            --output /tmp/chicory-compiler \
+            "https://maven-central.storage-download.googleapis.com/maven2/com/dylibso/chicory/build-time-compiler-cli-experimental/${CHICORY_VERSION}/build-time-compiler-cli-experimental-${CHICORY_VERSION}.sh"
+          echo "${CHICORY_COMPILER_SHA256}  /tmp/chicory-compiler" | sha256sum --check
+          chmod +x /tmp/chicory-compiler
+
+      - name: Compile WASM to JVM bytecode
+        run: |
+          mkdir -p target/chicory/{sources,classes,wasm}
+          /tmp/chicory-compiler target/wasm32-unknown-unknown/release/zen_internals.wasm \
+            --prefix dev.aikido.zeninternals.ZenInternals \
+            --source-dir target/chicory/sources \
+            --class-dir target/chicory/classes \
+            --wasm-dir target/chicory/wasm \
+            --interpreter-fallback FAIL

--- a/.github/workflows/jvm-wasm-compilation.yml
+++ b/.github/workflows/jvm-wasm-compilation.yml
@@ -39,7 +39,10 @@ jobs:
           sudo apt-get install -y binaryen
 
       - name: Build WASM
-        run: ./scripts/build-wasm.sh
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Optimize WASM
+        run: ./scripts/optimize-wasm.sh
 
       - name: Install Chicory compiler
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,11 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
+  jvm-wasm-compilation:
+    uses: ./.github/workflows/jvm-wasm-compilation.yml
+
   build:
-    needs: [tests, lint]
+    needs: [tests, lint, jvm-wasm-compilation]
     strategy:
       fail-fast: false
       matrix:
@@ -129,16 +132,16 @@ jobs:
           ${{ matrix.use_zig && 'cargo install --locked cargo-zigbuild' || format('rustup target add {0}', matrix.target) }}
 
       - name: Build
+        if: matrix.target != 'wasm32-unknown-unknown'
         run: |
           ${{ matrix.rustflags && format('RUSTFLAGS="{0}"', matrix.rustflags) || '' }} \
           ${{ matrix.use_zig && 'cargo zigbuild' || 'cargo build' }} \
           --target ${{ matrix.target }} --release
         shell: bash
 
-      - name: Optimize WASM
+      - name: Build WASM
         if: matrix.target == 'wasm32-unknown-unknown'
-        run: |
-          wasm-opt -O --enable-bulk-memory --enable-sign-ext --enable-nontrapping-float-to-int target/wasm32-unknown-unknown/release/zen_internals.wasm -o target/wasm32-unknown-unknown/release/zen_internals.wasm
+        run: ./scripts/build-wasm.sh
 
       - name: Prepare release (Unix)
         if: "!matrix.use_powershell"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,16 +132,15 @@ jobs:
           ${{ matrix.use_zig && 'cargo install --locked cargo-zigbuild' || format('rustup target add {0}', matrix.target) }}
 
       - name: Build
-        if: matrix.target != 'wasm32-unknown-unknown'
         run: |
           ${{ matrix.rustflags && format('RUSTFLAGS="{0}"', matrix.rustflags) || '' }} \
           ${{ matrix.use_zig && 'cargo zigbuild' || 'cargo build' }} \
           --target ${{ matrix.target }} --release
         shell: bash
 
-      - name: Build WASM
+      - name: Optimize WASM
         if: matrix.target == 'wasm32-unknown-unknown'
-        run: ./scripts/build-wasm.sh
+        run: ./scripts/optimize-wasm.sh
 
       - name: Prepare release (Unix)
         if: "!matrix.use_powershell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ members = [
 ]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory", "--enable-sign-ext", "--enable-nontrapping-float-to-int"]
+wasm-opt = ["-O", "--one-caller-inline-max-function-size=256", "--enable-bulk-memory", "--enable-sign-ext", "--enable-nontrapping-float-to-int"]

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+wasm_path="target/wasm32-unknown-unknown/release/zen_internals.wasm"
+
+cargo build --target wasm32-unknown-unknown --release
+
+# Limit single-caller inlining so Chicory does not generate JVM methods larger than 64 KB.
+wasm-opt \
+  -O \
+  --one-caller-inline-max-function-size=512 \
+  --enable-bulk-memory \
+  --enable-sign-ext \
+  --enable-nontrapping-float-to-int \
+  "$wasm_path" \
+  -o "$wasm_path"

--- a/scripts/optimize-wasm.sh
+++ b/scripts/optimize-wasm.sh
@@ -7,7 +7,7 @@ wasm_path="target/wasm32-unknown-unknown/release/zen_internals.wasm"
 # Limit single-caller inlining so Chicory does not generate JVM methods larger than 64 KB.
 wasm-opt \
   -O \
-  --one-caller-inline-max-function-size=512 \
+  --one-caller-inline-max-function-size=256 \
   --enable-bulk-memory \
   --enable-sign-ext \
   --enable-nontrapping-float-to-int \

--- a/scripts/optimize-wasm.sh
+++ b/scripts/optimize-wasm.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 
 wasm_path="target/wasm32-unknown-unknown/release/zen_internals.wasm"
 
-cargo build --target wasm32-unknown-unknown --release
-
 # Limit single-caller inlining so Chicory does not generate JVM methods larger than 64 KB.
 wasm-opt \
   -O \


### PR DESCRIPTION
Limit Binaryen single-caller inlining so Chicory can compile every WASM function to JVM bytecode.